### PR TITLE
Change requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ flask
 pillow
 requests
 wand
-rethinkdb
+rethinkdb==2.3.0.post6
 requests_oauthlib
 sentry_sdk
 blinker


### PR DESCRIPTION
Set version for rethinkdb lib as v2.40 seems to cause problems. See issue #60 for clarification.