### PR TITLE
Start server with async workers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ redis
 numpy
 keras
 scipy
+gevent
+tensorflow

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-gunicorn -w 32 -b 127.0.0.1:65535 server:app
+gunicorn -w 32 -b 127.0.0.1:65535 -k gevent server:app


### PR DESCRIPTION
Will need to run `sudo pip3 install -U -r requirements.txt`, then restart server. 
If there are issues, open start.sh and remove `-k gevent` from the arguments. 